### PR TITLE
update make file header for WSL Check

### DIFF
--- a/Makefile.header
+++ b/Makefile.header
@@ -5,7 +5,8 @@ else
 endif
 
 ifeq ($(detected_OS), Linux)
-	ifdef WSL_DISTRO_NAME
+	WSL_CHECK := $(shell uname -a)
+	ifneq (,findstring(Microsoft,$(WSL_CHECK)))
 		detected_OS := WSL
 	endif
 	OS_Name := $(shell uname -o)


### PR DESCRIPTION
original WSL_DISTRO_NAME is not defined in WSL system, thus not reliable. uname -a to check if "Microsoft" exists will be more reliable.